### PR TITLE
Add Telegram job fetcher service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app app
+ENV API_TOKEN=secret
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # job_searcher_bot
+
 This bot will filter all incoming job offers using AI prompt
+
+## Running the HTTP service
+
+The project exposes an HTTP service that scrapes the [easy_qa_jobs](https://t.me/easy_qa_jobs) Telegram channel and returns job posts for a specified duration.
+
+### Docker Compose
+
+1. Ensure Docker and Docker Compose are installed.
+2. Set the `API_TOKEN` environment variable (defaults to `secret`).
+3. Build and start the service:
+
+   ```bash
+   docker-compose up --build
+   ```
+
+4. Query the service:
+
+   ```bash
+   curl -H "Authorization: Bearer secret" "http://localhost:8000/jobs?duration=3%20days"
+   ```
+
+### Local execution
+
+1. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Run the service:
+
+   ```bash
+   API_TOKEN=secret uvicorn app.main:app --reload
+   ```
+
+3. Query the service as shown above.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,80 @@
+from fastapi import FastAPI, HTTPException, Depends
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+import os
+import re
+from datetime import datetime, timedelta, timezone
+from typing import List, Dict
+import requests
+from bs4 import BeautifulSoup
+
+app = FastAPI()
+security = HTTPBearer()
+
+
+def parse_duration(duration_str: str) -> timedelta:
+    pattern = r"^\s*(\d+)\s*(seconds?|minutes?|hours?|days?|weeks?|months?|years?)\s*$"
+    match = re.match(pattern, duration_str, re.IGNORECASE)
+    if not match:
+        raise HTTPException(status_code=400, detail="Invalid duration format")
+    value = int(match.group(1))
+    unit = match.group(2).lower()
+    if unit.startswith("second"):
+        return timedelta(seconds=value)
+    if unit.startswith("minute"):
+        return timedelta(minutes=value)
+    if unit.startswith("hour"):
+        return timedelta(hours=value)
+    if unit.startswith("day"):
+        return timedelta(days=value)
+    if unit.startswith("week"):
+        return timedelta(weeks=value)
+    if unit.startswith("month"):
+        return timedelta(days=30 * value)
+    if unit.startswith("year"):
+        return timedelta(days=365 * value)
+    raise HTTPException(status_code=400, detail="Unsupported duration unit")
+
+
+def fetch_posts(channel: str, since: datetime) -> List[Dict[str, str]]:
+    posts: List[Dict[str, str]] = []
+    base_url = f"https://t.me/s/{channel}"
+    before = None
+    while True:
+        url = base_url if before is None else f"{base_url}?before={before}"
+        resp = requests.get(url, timeout=10)
+        if not resp.ok:
+            break
+        soup = BeautifulSoup(resp.text, "html.parser")
+        wrappers = soup.select("div.tgme_widget_message_wrap")
+        if not wrappers:
+            break
+        for wrap in wrappers:
+            message = wrap.select_one("div.tgme_widget_message")
+            if not message:
+                continue
+            time_tag = message.select_one("time")
+            if not time_tag or not time_tag.get("datetime"):
+                continue
+            dt = datetime.fromisoformat(time_tag["datetime"])
+            if dt < since:
+                return posts
+            text_elem = message.select_one("div.tgme_widget_message_text")
+            text = text_elem.get_text("\n") if text_elem else ""
+            post_id = message.get("data-post", "")
+            posts.append({"id": post_id, "date": dt.isoformat(), "text": text})
+        last = wrappers[-1].select_one("div.tgme_widget_message")
+        if not last:
+            break
+        before = last.get("data-post", "").split("/")[-1]
+    return posts
+
+
+@app.get("/jobs")
+def get_jobs(duration: str, credentials: HTTPAuthorizationCredentials = Depends(security)):
+    token = os.getenv("API_TOKEN", "secret")
+    if credentials.credentials != token:
+        raise HTTPException(status_code=401, detail="Invalid token")
+    delta = parse_duration(duration)
+    since = datetime.now(timezone.utc) - delta
+    posts = fetch_posts("easy_qa_jobs", since)
+    return {"count": len(posts), "posts": posts}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.9'
+services:
+  web:
+    build: .
+    ports:
+      - '8000:8000'
+    environment:
+      API_TOKEN: ${API_TOKEN:-secret}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+requests
+beautifulsoup4


### PR DESCRIPTION
## Summary
- implement FastAPI service that fetches Telegram posts from easy_qa_jobs for a duration
- add Dockerfile and docker-compose for running the service
- document usage in README

## Testing
- `python -m py_compile app/main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b84e1ee6fc8322b8dca53befb05cbe